### PR TITLE
Feat/my article

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -21,6 +21,7 @@ const Router = () => {
             <Route path="/mypage" element={<Mypage />} />
             <Route path="/mypage/article" element={<Mypage />} />
             <Route path="/mypage/comment" element={<Mypage />} />
+            <Route path="/mypage/liked" element={<Mypage />} />
             <Route path="/writing" element={<Writing />} />
             <Route path="/article/:id" element={<Article />} />
           </Route>

--- a/src/Router.js
+++ b/src/Router.js
@@ -19,7 +19,8 @@ const Router = () => {
             <Route exact path="/" element={<Main />} />
             <Route path="/category/:id" element={<Category />} />
             <Route path="/mypage" element={<Mypage />} />
-            <Route path="/mypage/:isarticle" element={<Mypage />} />
+            <Route path="/mypage/article" element={<Mypage />} />
+            <Route path="/mypage/comment" element={<Mypage />} />
             <Route path="/writing" element={<Writing />} />
             <Route path="/article/:id" element={<Article />} />
           </Route>

--- a/src/Router.js
+++ b/src/Router.js
@@ -19,6 +19,7 @@ const Router = () => {
             <Route exact path="/" element={<Main />} />
             <Route path="/category/:id" element={<Category />} />
             <Route path="/mypage" element={<Mypage />} />
+            <Route path="/mypage/:isarticle" element={<Mypage />} />
             <Route path="/writing" element={<Writing />} />
             <Route path="/article/:id" element={<Article />} />
           </Route>

--- a/src/components/organisms/mypage/CharSelectModal.jsx
+++ b/src/components/organisms/mypage/CharSelectModal.jsx
@@ -61,7 +61,6 @@ const CharSelectModal = ({ isOpen, setIsOpen }) => {
 
 const CharSelectContainer = styled(ModalContainer)`
   width: 40%;
-  height: fit-content;
 
   &:focus {
     outline: none;
@@ -70,7 +69,6 @@ const CharSelectContainer = styled(ModalContainer)`
 
   h1 {
     margin: 0.6rem 0.1rem 0.6rem 0.5rem;
-    height: fit-content;
     font-size: 1.6rem;
   }
   hr {

--- a/src/components/organisms/mypage/MyArticleBoard.jsx
+++ b/src/components/organisms/mypage/MyArticleBoard.jsx
@@ -1,12 +1,15 @@
-import { useState, useEffect } from "react";
+import { useState, useRef, useEffect } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import styled from "styled-components";
 
 import { UserService } from "../../../network";
-import PreviewArticle from "../../organisms/category/PreviewArticle";
+import PreviewArticle from "../category/PreviewArticle";
+import MyArticlePageSelector from "./MyArticlePageSelector";
 
 const MyArticleBoard = ({ isComment }) => {
   const [articles, setArticles] = useState(null);
+  const [page, setPage] = useState(1);
+  const [pageCount, setPageCount] = useState(1);
   const navi = useNavigate();
 
   const handleClickGoBack = () => {
@@ -16,13 +19,14 @@ const MyArticleBoard = ({ isComment }) => {
   useEffect(() => {
     const fetchMyArticles = async () => {
       const response = isComment
-        ? await UserService.getMyComments()
-        : await UserService.getMyArticles();
+        ? await UserService.getMyComments(page)
+        : await UserService.getMyArticles(page);
       setArticles(response.data);
+      setPageCount(response.meta.pageCount);
     };
 
     fetchMyArticles();
-  }, [isComment]);
+  }, [isComment, page]);
 
   return (
     <MyArticleWrapper>
@@ -31,7 +35,7 @@ const MyArticleBoard = ({ isComment }) => {
       </div>
       <hr />
       <div className="go-back" onClick={handleClickGoBack}>
-        {"< 돌아가기"}
+        &lt; 돌아가기
       </div>
       <div className="article-list">
         {articles &&
@@ -44,6 +48,11 @@ const MyArticleBoard = ({ isComment }) => {
             </Link>
           ))}
       </div>
+      <MyArticlePageSelector
+        curPage={page}
+        setCurPage={setPage}
+        pageCount={pageCount}
+      />
     </MyArticleWrapper>
   );
 };

--- a/src/components/organisms/mypage/MyArticleBoard.jsx
+++ b/src/components/organisms/mypage/MyArticleBoard.jsx
@@ -71,14 +71,12 @@ const MyArticleBoard = ({ articleType }) => {
 
 const MyArticleWrapper = styled.div`
   width: 100%;
-  height: fit-content;
   margin: 1rem 0;
   padding: 0.3rem;
   border-radius: ${(props) => props.theme.borderRadius};
   box-shadow: ${(props) => props.theme.boxShadow};
   h1 {
     margin: 0.3rem 0.1rem 0.6rem 0.5rem;
-    height: fit-content;
     font-size: 1.6rem;
   }
   hr {

--- a/src/components/organisms/mypage/MyArticleBoard.jsx
+++ b/src/components/organisms/mypage/MyArticleBoard.jsx
@@ -44,9 +44,9 @@ const MyArticleBoard = ({ articleType }) => {
             ? "내 댓글"
             : "좋아요한 글"}
         </h1>
-        <span className="go-back" onClick={handleClickGoBack}>
-          &lt; 돌아가기
-        </span>
+        <button className="go-back" onClick={handleClickGoBack}>
+          {"< 돌아가기"}
+        </button>
       </div>
       <div className="article-list">
         {articles &&
@@ -87,8 +87,9 @@ const MyArticleWrapper = styled.div`
       font-weight: bold;
     }
     .go-back {
-      margin: 1rem 0.8rem;
-      font-size: 0.9rem;
+      margin: 0.5rem;
+      border: none;
+      background: transparent;
       cursor: pointer;
     }
   }

--- a/src/components/organisms/mypage/MyArticleBoard.jsx
+++ b/src/components/organisms/mypage/MyArticleBoard.jsx
@@ -12,8 +12,8 @@ const MyArticleBoard = ({ articleType }) => {
   const [pageCount, setPageCount] = useState(1);
   const navi = useNavigate();
   const ARTICLE = 1,
-    COMMENT = 2,
-    LIKED = 3;
+    COMMENT = 2;
+  //LIKED = 3;
 
   const handleClickGoBack = () => {
     navi("/mypage");

--- a/src/components/organisms/mypage/MyArticleBoard.jsx
+++ b/src/components/organisms/mypage/MyArticleBoard.jsx
@@ -1,26 +1,70 @@
+import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 
+import { UserService } from "../../../network";
 import PreviewArticle from "../category";
 
 const MyArticleBoard = ({ isComment }) => {
+  const [articles, setArticles] = useState(null);
+  const navi = useNavigate();
+
+  const handleClickGoBack = () => {
+    navi("/mypage");
+  };
+
+  useEffect(() => {
+    const fetchMyArticles = async () => {
+      const response = isComment
+        ? await UserService.getMyComments()
+        : await UserService.getMyArticles();
+      setArticles(response.data.slice(0, 5));
+    };
+
+    fetchMyArticles();
+  }, [isComment]);
+
   return (
     <MyArticleWrapper>
-      <div className="board-header">
+      <div>
         <h1>{isComment ? "내 댓글" : "내 게시글"}</h1>
       </div>
+      <hr />
+      <div className="go-back" onClick={handleClickGoBack}>
+        {"< 돌아가기"}
+      </div>
+      <div className="article-list">{/* map -> article 표시 */}</div>
     </MyArticleWrapper>
   );
 };
 
 const MyArticleWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  border-radius: 0.3rem;
+  width: 100%;
+  height: fit-content;
+  margin: 1rem 0;
+  padding: 0.3rem;
+  border-radius: ${(props) => props.theme.borderRadius};
   box-shadow: ${(props) => props.theme.boxShadow};
-  background-color: #fff;
-  .articleList_content {
-    text-decoration: none;
-    color: ${(props) => props.theme.black};
+  h1 {
+    margin: 0.3rem 0.1rem 0.6rem 0.5rem;
+    height: fit-content;
+    font-size: 1.6rem;
+  }
+  hr {
+    color: ${(props) => props.theme.LineGray1};
+  }
+  .go-back {
+    margin: 0.3rem 0;
+    padding: 0.3rem;
+    &:hover {
+      cursor: pointer;
+    }
+  }
+  ${(props) => props.theme.mobileSize} {
+    box-shadow: none;
+    border-bottom: 1px solid ${(props) => props.theme.lineGray1};
+    border-radius: 0;
+    margin: 0;
   }
 `;
 

--- a/src/components/organisms/mypage/MyArticleBoard.jsx
+++ b/src/components/organisms/mypage/MyArticleBoard.jsx
@@ -6,11 +6,14 @@ import { UserService } from "../../../network";
 import PreviewArticle from "../category/PreviewArticle";
 import MyArticlePageSelector from "./MyArticlePageSelector";
 
-const MyArticleBoard = ({ isComment }) => {
+const MyArticleBoard = ({ articleType }) => {
   const [articles, setArticles] = useState(null);
   const [page, setPage] = useState(1);
   const [pageCount, setPageCount] = useState(1);
   const navi = useNavigate();
+  const ARTICLE = 1,
+    COMMENT = 2,
+    LIKED = 3;
 
   const handleClickGoBack = () => {
     navi("/mypage");
@@ -18,20 +21,29 @@ const MyArticleBoard = ({ isComment }) => {
 
   useEffect(() => {
     const fetchMyArticles = async () => {
-      const response = isComment
-        ? await UserService.getMyComments(page)
-        : await UserService.getMyArticles(page);
+      const response =
+        articleType === ARTICLE
+          ? await UserService.getMyArticles(page)
+          : articleType === COMMENT
+          ? await UserService.getMyComments(page)
+          : await UserService.getLikeArticles(page);
       setArticles(response.data);
       setPageCount(response.meta.pageCount);
     };
 
     fetchMyArticles();
-  }, [isComment, page]);
+  }, [articleType, page]);
 
   return (
     <MyArticleWrapper>
       <div>
-        <h1>{isComment ? "내 댓글" : "내 게시글"}</h1>
+        <h1>
+          {articleType === ARTICLE
+            ? "내 게시글"
+            : articleType === COMMENT
+            ? "내 댓글"
+            : "좋아요한 글"}
+        </h1>
       </div>
       <hr />
       <div className="go-back" onClick={handleClickGoBack}>

--- a/src/components/organisms/mypage/MyArticleBoard.jsx
+++ b/src/components/organisms/mypage/MyArticleBoard.jsx
@@ -61,14 +61,22 @@ const MyArticleWrapper = styled.div`
     font-size: 1.6rem;
   }
   hr {
-    color: ${(props) => props.theme.LineGray1};
+    border: 0;
+    height: 1px;
+    background-color: ${(props) => props.theme.lineGray1};
   }
   .go-back {
     margin: 0.3rem 0;
     padding: 0.3rem;
+    line-height: 1.3rem;
+    border-bottom: 1px solid ${(props) => props.theme.lineGray1};
     &:hover {
       cursor: pointer;
     }
+  }
+  .article-content {
+    text-decoration: none;
+    color: ${(props) => props.theme.black};
   }
   ${(props) => props.theme.mobileSize} {
     box-shadow: none;

--- a/src/components/organisms/mypage/MyArticleBoard.jsx
+++ b/src/components/organisms/mypage/MyArticleBoard.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import styled from "styled-components";
 

--- a/src/components/organisms/mypage/MyArticleBoard.jsx
+++ b/src/components/organisms/mypage/MyArticleBoard.jsx
@@ -66,7 +66,6 @@ const MyArticleWrapper = styled.div`
     background-color: ${(props) => props.theme.lineGray1};
   }
   .go-back {
-    margin: 0.3rem 0;
     padding: 0.3rem;
     line-height: 1.3rem;
     border-bottom: 1px solid ${(props) => props.theme.lineGray1};

--- a/src/components/organisms/mypage/MyArticleBoard.jsx
+++ b/src/components/organisms/mypage/MyArticleBoard.jsx
@@ -1,0 +1,27 @@
+import styled from "styled-components";
+
+import PreviewArticle from "../category";
+
+const MyArticleBoard = ({ isComment }) => {
+  return (
+    <MyArticleWrapper>
+      <div className="board-header">
+        <h1>{isComment ? "내 댓글" : "내 게시글"}</h1>
+      </div>
+    </MyArticleWrapper>
+  );
+};
+
+const MyArticleWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  border-radius: 0.3rem;
+  box-shadow: ${(props) => props.theme.boxShadow};
+  background-color: #fff;
+  .articleList_content {
+    text-decoration: none;
+    color: ${(props) => props.theme.black};
+  }
+`;
+
+export default MyArticleBoard;

--- a/src/components/organisms/mypage/MyArticleBoard.jsx
+++ b/src/components/organisms/mypage/MyArticleBoard.jsx
@@ -1,9 +1,9 @@
 import { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import styled from "styled-components";
 
 import { UserService } from "../../../network";
-import PreviewArticle from "../category";
+import PreviewArticle from "../../organisms/category/PreviewArticle";
 
 const MyArticleBoard = ({ isComment }) => {
   const [articles, setArticles] = useState(null);
@@ -18,7 +18,7 @@ const MyArticleBoard = ({ isComment }) => {
       const response = isComment
         ? await UserService.getMyComments()
         : await UserService.getMyArticles();
-      setArticles(response.data.slice(0, 5));
+      setArticles(response.data);
     };
 
     fetchMyArticles();
@@ -33,7 +33,17 @@ const MyArticleBoard = ({ isComment }) => {
       <div className="go-back" onClick={handleClickGoBack}>
         {"< 돌아가기"}
       </div>
-      <div className="article-list">{/* map -> article 표시 */}</div>
+      <div className="article-list">
+        {articles &&
+          articles.map((article, id) => (
+            <Link
+              to={`/article/${article.id}`}
+              className="article-content"
+              key={id}>
+              <PreviewArticle article={article} />
+            </Link>
+          ))}
+      </div>
     </MyArticleWrapper>
   );
 };

--- a/src/components/organisms/mypage/MyArticleBoard.jsx
+++ b/src/components/organisms/mypage/MyArticleBoard.jsx
@@ -36,7 +36,7 @@ const MyArticleBoard = ({ articleType }) => {
 
   return (
     <MyArticleWrapper>
-      <div>
+      <div className="title">
         <h1>
           {articleType === ARTICLE
             ? "내 게시글"
@@ -44,10 +44,9 @@ const MyArticleBoard = ({ articleType }) => {
             ? "내 댓글"
             : "좋아요한 글"}
         </h1>
-      </div>
-      <hr />
-      <div className="go-back" onClick={handleClickGoBack}>
-        &lt; 돌아가기
+        <span className="go-back" onClick={handleClickGoBack}>
+          &lt; 돌아가기
+        </span>
       </div>
       <div className="article-list">
         {articles &&
@@ -55,7 +54,8 @@ const MyArticleBoard = ({ articleType }) => {
             <Link
               to={`/article/${article.id}`}
               className="article-content"
-              key={id}>
+              key={id}
+            >
               <PreviewArticle article={article} />
             </Link>
           ))}
@@ -75,23 +75,24 @@ const MyArticleWrapper = styled.div`
   padding: 0.3rem;
   border-radius: ${(props) => props.theme.borderRadius};
   box-shadow: ${(props) => props.theme.boxShadow};
-  h1 {
-    margin: 0.3rem 0.1rem 0.6rem 0.5rem;
-    font-size: 1.6rem;
-  }
-  hr {
-    border: 0;
-    height: 1px;
-    background-color: ${(props) => props.theme.lineGray1};
-  }
-  .go-back {
-    padding: 0.3rem;
-    line-height: 1.3rem;
+
+  .title {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
     border-bottom: 1px solid ${(props) => props.theme.lineGray1};
-    &:hover {
+    h1 {
+      margin: 1rem 0.8rem;
+      font-size: 1.4rem;
+      font-weight: bold;
+    }
+    .go-back {
+      margin: 1rem 0.8rem;
+      font-size: 0.9rem;
       cursor: pointer;
     }
   }
+
   .article-content {
     text-decoration: none;
     color: ${(props) => props.theme.black};

--- a/src/components/organisms/mypage/MyArticlePageSelector.jsx
+++ b/src/components/organisms/mypage/MyArticlePageSelector.jsx
@@ -1,0 +1,83 @@
+import styled from "styled-components";
+
+const MyArticlePageSelector = ({ curPage, setCurPage, pageCount }) => {
+  const handleClickPrevBtn = () => {
+    setCurPage(1);
+  };
+
+  const handleClickNextBtn = () => {
+    setCurPage(pageCount);
+  };
+
+  const getPageList = () => {
+    const pageList = [];
+    if (pageCount < 5) {
+      for (let i = 1; i <= pageCount; i++) {
+        pageList.push(i);
+      }
+    } else if (curPage > 2 && curPage < pageCount - 2) {
+      for (let i = curPage - 2; i <= curPage + 2; i++) {
+        pageList.push(i);
+      }
+    } else if (curPage <= 3) {
+      for (let i = 1; i <= 5; i++) {
+        pageList.push(i);
+      }
+    } else if (curPage >= pageCount - 3) {
+      for (let i = pageCount - 4; i <= pageCount; i++) {
+        pageList.push(i);
+      }
+    }
+    console.log(pageCount);
+    return pageList;
+  };
+
+  return (
+    <MyArticlePageSelectorWrapper>
+      <button onClick={handleClickPrevBtn}>&lt;</button>
+      {getPageList().map((page) => {
+        if (page === curPage) {
+          return (
+            <button
+              key={page}
+              onClick={() => setCurPage(page)}
+              className="cur-page">
+              {page}
+            </button>
+          );
+        } else {
+          return (
+            <button key={page} onClick={() => setCurPage(page)}>
+              {page}
+            </button>
+          );
+        }
+      })}
+      <button onClick={handleClickNextBtn}>&gt;</button>
+    </MyArticlePageSelectorWrapper>
+  );
+};
+
+const MyArticlePageSelectorWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.3rem;
+  background-color: ${(props) => props.theme.backgroundWhite};
+
+  button {
+    border: none;
+    background-color: ${(props) => props.theme.backgroundWhite};
+    color: ${(props) => props.theme.textBlack};
+    padding: 0.3rem 0.5rem;
+    margin: 0.2rem;
+    border-radius: 0.3rem;
+  }
+  .cur-page {
+    background-color: ${(props) => props.theme.primary};
+    color: ${(props) => props.theme.textWhite};
+  }
+`;
+
+export default MyArticlePageSelector;

--- a/src/components/organisms/mypage/MyArticlePageSelector.jsx
+++ b/src/components/organisms/mypage/MyArticlePageSelector.jsx
@@ -64,6 +64,7 @@ const MyArticlePageSelectorWrapper = styled.div`
   align-items: center;
   justify-content: center;
   border-radius: 0.3rem;
+  margin-top: 0.3rem;
   background-color: ${(props) => props.theme.backgroundWhite};
 
   button {

--- a/src/components/organisms/mypage/MyArticlePreview.jsx
+++ b/src/components/organisms/mypage/MyArticlePreview.jsx
@@ -29,6 +29,7 @@ const MyArticlePreview = ({ ifComment }) => {
         articles.map((article) => (
           <ArticlePreview
             key={article.id}
+            id={article.id}
             title={ifComment ? article.content : article.title}
             likeCount={ifComment ? "" : article.commentCount}
             commentCount={ifComment ? "" : article.commentCount}

--- a/src/components/organisms/mypage/MyArticlePreview.jsx
+++ b/src/components/organisms/mypage/MyArticlePreview.jsx
@@ -6,29 +6,50 @@ import { ArticlePreview } from "../main";
 
 import { UserService } from "../../../network";
 
-const MyArticlePreview = ({ isComment }) => {
+const MyArticlePreview = ({ articleType }) => {
   const [articles, setArticles] = useState(null);
   const navi = useNavigate();
+  const ARTICLE = 1,
+    COMMENT = 2,
+    LIKED = 3;
 
   const handleClickMoreBtn = () => {
-    navi(`./${isComment ? "comment" : "article"}`);
+    navi(
+      `./${
+        articleType === ARTICLE
+          ? "article"
+          : articleType === COMMENT
+          ? "comment"
+          : "liked"
+      }`
+    );
   };
 
   useEffect(() => {
     const fetchMyArticles = async () => {
-      const response = isComment
-        ? await UserService.getMyComments()
-        : await UserService.getMyArticles();
-      setArticles(response.data.slice(0, 5));
+      const response =
+        articleType === ARTICLE
+          ? await UserService.getMyArticles(1)
+          : articleType === COMMENT
+          ? await UserService.getMyComments(1)
+          : await UserService.getLikeArticles(1);
+      console.log(response.data);
+      setArticles(response.data && response.data.slice(0, 5));
     };
 
     fetchMyArticles();
-  }, [isComment]);
+  }, [articleType]);
 
   return (
-    <MyArticleDiv isComment={isComment}>
+    <MyArticleDiv articleType={articleType}>
       <div className="title">
-        <h1>{isComment ? "내 댓글" : "내 게시글"}</h1>
+        <h1>
+          {articleType === ARTICLE
+            ? "내 게시글"
+            : articleType === COMMENT
+            ? "내 댓글"
+            : "좋아요한 글"}
+        </h1>
         <button className="more" onClick={handleClickMoreBtn}>
           {"더 보기 >"}
         </button>
@@ -38,9 +59,9 @@ const MyArticlePreview = ({ isComment }) => {
           <ArticlePreview
             key={article.id}
             id={article.id}
-            title={isComment ? article.content : article.title}
-            likeCount={isComment ? "" : article.commentCount}
-            commentCount={isComment ? "" : article.commentCount}
+            title={articleType === COMMENT ? article.content : article.title}
+            likeCount={articleType ? "" : article.commentCount}
+            commentCount={articleType ? "" : article.commentCount}
           />
         ))}
     </MyArticleDiv>

--- a/src/components/organisms/mypage/MyArticlePreview.jsx
+++ b/src/components/organisms/mypage/MyArticlePreview.jsx
@@ -1,4 +1,5 @@
-import { useState, useEffect } from "react";
+import { React, useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 
 import { ArticlePreview } from "../main";
@@ -7,6 +8,11 @@ import { UserService } from "../../../network";
 
 const MyArticlePreview = ({ isComment }) => {
   const [articles, setArticles] = useState(null);
+  const navi = useNavigate();
+
+  const handleClickMoreBtn = () => {
+    navi(`./${isComment ? "comments" : "articles"}`);
+  };
 
   useEffect(() => {
     const fetchMyArticles = async () => {
@@ -23,7 +29,9 @@ const MyArticlePreview = ({ isComment }) => {
     <MyArticleDiv isComment={isComment}>
       <div className="title">
         <h1>{isComment ? "내 댓글" : "내 게시글"}</h1>
-        <button className="more">{"더 보기 >"}</button>
+        <button className="more" onClick={handleClickMoreBtn}>
+          {"더 보기 >"}
+        </button>
       </div>
       {articles &&
         articles.map((article) => (

--- a/src/components/organisms/mypage/MyArticlePreview.jsx
+++ b/src/components/organisms/mypage/MyArticlePreview.jsx
@@ -110,6 +110,9 @@ const MyArticleDiv = styled.div`
     border-radius: 0;
     width: 100%;
     margin: 0;
+    .title {
+      background-color: ${(props) => props.theme.backgroundGray2};
+    }
   }
 `;
 

--- a/src/components/organisms/mypage/MyArticlePreview.jsx
+++ b/src/components/organisms/mypage/MyArticlePreview.jsx
@@ -11,7 +11,7 @@ const MyArticlePreview = ({ isComment }) => {
   const navi = useNavigate();
 
   const handleClickMoreBtn = () => {
-    navi(`./${isComment ? "comments" : "articles"}`);
+    navi(`./${isComment ? "comment" : "article"}`);
   };
 
   useEffect(() => {

--- a/src/components/organisms/mypage/MyArticlePreview.jsx
+++ b/src/components/organisms/mypage/MyArticlePreview.jsx
@@ -85,6 +85,7 @@ const MyArticleDiv = styled.div`
     border-bottom: 1px solid ${(props) => props.theme.lineGray1};
     border-radius: 0;
     width: 100%;
+    height: fit-content;
     margin: 0;
   }
 `;

--- a/src/components/organisms/mypage/MyArticlePreview.jsx
+++ b/src/components/organisms/mypage/MyArticlePreview.jsx
@@ -76,7 +76,7 @@ const MyArticleDiv = styled.div`
   margin: 0.5rem 0;
 
   width: ${(props) =>
-      props.articleType === 3 ? "calc(100% - 0.4rem);" : "calc(50% - 0.8rem);"}
+      props.articleType === 3 ? "calc(100%);" : "calc(50% - 0.8rem);"}
     .title {
     padding: 0.5rem;
     display: flex;

--- a/src/components/organisms/mypage/MyArticlePreview.jsx
+++ b/src/components/organisms/mypage/MyArticlePreview.jsx
@@ -55,7 +55,7 @@ const MyArticleDiv = styled.div`
   margin: 0.5rem 0;
 
   width: calc(50% - 0.8rem);
-  height: fit-content;
+  height: 13rem;
   .title {
     padding: 0.5rem;
     display: flex;

--- a/src/components/organisms/mypage/MyArticlePreview.jsx
+++ b/src/components/organisms/mypage/MyArticlePreview.jsx
@@ -76,17 +76,20 @@ const MyArticleDiv = styled.div`
   margin: 0.5rem 0;
 
   width: ${(props) =>
-      props.articleType === 3 ? "calc(100%);" : "calc(50% - 0.8rem);"}
-    .title {
+    props.articleType === 3 ? "calc(100%);" : "calc(50% - 0.8rem);"};
+  .title {
     padding: 0.5rem;
     display: flex;
     justify-content: space-between;
+    border-bottom: 1px solid ${(props) => props.theme.lineGray1};
     h1 {
       display: flex;
       align-items: center;
       font-weight: 700;
+      margin: 0.3rem;
     }
     button {
+      margin: 0.3rem;
       border: none;
       background: transparent;
       cursor: pointer;

--- a/src/components/organisms/mypage/MyArticlePreview.jsx
+++ b/src/components/organisms/mypage/MyArticlePreview.jsx
@@ -10,8 +10,8 @@ const MyArticlePreview = ({ articleType }) => {
   const [articles, setArticles] = useState(null);
   const navi = useNavigate();
   const ARTICLE = 1,
-    COMMENT = 2,
-    LIKED = 3;
+    COMMENT = 2;
+  //LIKED = 3;
 
   const handleClickMoreBtn = () => {
     navi(

--- a/src/components/organisms/mypage/MyArticlePreview.jsx
+++ b/src/components/organisms/mypage/MyArticlePreview.jsx
@@ -5,24 +5,24 @@ import { ArticlePreview } from "../main";
 
 import { UserService } from "../../../network";
 
-const MyArticlePreview = ({ ifComment }) => {
+const MyArticlePreview = ({ isComment }) => {
   const [articles, setArticles] = useState(null);
 
   useEffect(() => {
     const fetchMyArticles = async () => {
-      const response = ifComment
+      const response = isComment
         ? await UserService.getMyComments()
         : await UserService.getMyArticles();
       setArticles(response.data.slice(0, 5));
     };
 
     fetchMyArticles();
-  }, [ifComment]);
+  }, [isComment]);
 
   return (
-    <MyArticleDiv ifComment={ifComment}>
+    <MyArticleDiv isComment={isComment}>
       <div className="title">
-        <h1>{ifComment ? "내 댓글" : "내 게시글"}</h1>
+        <h1>{isComment ? "내 댓글" : "내 게시글"}</h1>
         <button className="more">{"더 보기 >"}</button>
       </div>
       {articles &&
@@ -30,9 +30,9 @@ const MyArticlePreview = ({ ifComment }) => {
           <ArticlePreview
             key={article.id}
             id={article.id}
-            title={ifComment ? article.content : article.title}
-            likeCount={ifComment ? "" : article.commentCount}
-            commentCount={ifComment ? "" : article.commentCount}
+            title={isComment ? article.content : article.title}
+            likeCount={isComment ? "" : article.commentCount}
+            commentCount={isComment ? "" : article.commentCount}
           />
         ))}
     </MyArticleDiv>
@@ -70,7 +70,7 @@ const MyArticleDiv = styled.div`
   }
   .like,
   .comment {
-    display: ${(props) => (props.ifComment ? "none" : "block")};
+    display: ${(props) => (props.isComment ? "none" : "block")};
   }
   ${(props) => props.theme.mobileSize} {
     box-shadow: none;

--- a/src/components/organisms/mypage/MyArticlePreview.jsx
+++ b/src/components/organisms/mypage/MyArticlePreview.jsx
@@ -106,7 +106,6 @@ const MyArticleDiv = styled.div`
     border-bottom: 1px solid ${(props) => props.theme.lineGray1};
     border-radius: 0;
     width: 100%;
-    height: fit-content;
     margin: 0;
   }
 `;

--- a/src/components/organisms/mypage/MyArticlePreview.jsx
+++ b/src/components/organisms/mypage/MyArticlePreview.jsx
@@ -75,9 +75,9 @@ const MyArticleDiv = styled.div`
 
   margin: 0.5rem 0;
 
-  width: calc(50% - 0.8rem);
-  height: 13rem;
-  .title {
+  width: ${(props) =>
+      props.articleType === 3 ? "calc(100% - 0.4rem);" : "calc(50% - 0.8rem);"}
+    .title {
     padding: 0.5rem;
     display: flex;
     justify-content: space-between;
@@ -99,7 +99,7 @@ const MyArticleDiv = styled.div`
   }
   .like,
   .comment {
-    display: ${(props) => (props.isComment ? "none" : "block")};
+    display: ${(props) => (props.articleType === 2 ? "none" : "block")};
   }
   ${(props) => props.theme.mobileSize} {
     box-shadow: none;

--- a/src/components/organisms/mypage/MyProfile.jsx
+++ b/src/components/organisms/mypage/MyProfile.jsx
@@ -41,6 +41,7 @@ const MyProfileDiv = styled.div`
     font-size: 1.6rem;
   }
   h1 {
+    // TODO : 이부분 스타일이 적용되지 않는 것 같아 논의 필요
     margin: 0.5rem 0.1rem;
     margin-left: 1rem;
     height: 2.4rem;

--- a/src/components/organisms/mypage/MyProfile.jsx
+++ b/src/components/organisms/mypage/MyProfile.jsx
@@ -31,13 +31,11 @@ const MyProfileDiv = styled.div`
   background-color: ${(props) => props.theme.white};
   box-shadow: ${(props) => props.theme.boxShadow};
   width: 100%;
-  height: fit-content;
   margin: 1rem 0;
   padding: 0.3rem;
   border-radius: ${(props) => props.theme.borderRadius};
   .profile-title {
     margin: 0.3rem 0.1rem 0.6rem 0.5rem;
-    height: fit-content;
     font-size: 1.6rem;
   }
   h1 {

--- a/src/components/organisms/mypage/MyProfile.jsx
+++ b/src/components/organisms/mypage/MyProfile.jsx
@@ -48,7 +48,9 @@ const MyProfileDiv = styled.div`
     font-size: 2rem;
   }
   hr {
-    color: ${(props) => props.theme.LineGray1};
+    border: 0;
+    height: 1px;
+    background-color: ${(props) => props.theme.lineGray1};
   }
   .profile-section {
     display: flex;

--- a/src/components/organisms/mypage/MyProfile.jsx
+++ b/src/components/organisms/mypage/MyProfile.jsx
@@ -35,15 +35,9 @@ const MyProfileDiv = styled.div`
   padding: 0.3rem;
   border-radius: ${(props) => props.theme.borderRadius};
   .profile-title {
-    margin: 0.3rem 0.1rem 0.6rem 0.5rem;
-    font-size: 1.6rem;
-  }
-  h1 {
-    // TODO : 이부분 스타일이 적용되지 않는 것 같아 논의 필요
-    margin: 0.5rem 0.1rem;
-    margin-left: 1rem;
-    height: 2.4rem;
-    font-size: 2rem;
+    margin: 1rem 0.8rem;
+    font-size: 1.5rem;
+    font-weight: bold;
   }
   hr {
     border: 0;
@@ -54,7 +48,6 @@ const MyProfileDiv = styled.div`
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-    height: calc(100% - 2rem - 0.6rem);
     @media screen and (min-width: 481px) {
       flex-direction: row;
     }

--- a/src/components/organisms/mypage/ProfileSection.jsx
+++ b/src/components/organisms/mypage/ProfileSection.jsx
@@ -53,7 +53,6 @@ const ProfileSectionDiv = styled.div`
   min-width: 15rem;
   align-items: center;
   .mypage-photo-sect {
-    width: fit-content;
     padding: 0.5rem;
     display: flex;
     flex-direction: column;

--- a/src/components/organisms/mypage/index.js
+++ b/src/components/organisms/mypage/index.js
@@ -1,3 +1,5 @@
 export { default as MyProfile } from "./MyProfile";
 
 export { default as MyArticlePreview } from "./MyArticlePreview";
+
+export { default as MyArticleBoard } from "./MyArticleBoard";

--- a/src/components/pages/Mypage.jsx
+++ b/src/components/pages/Mypage.jsx
@@ -12,21 +12,31 @@ import {
 
 const Mypage = () => {
   const loc = useLocation();
-  const isArticle = loc.pathname.split("/")[2];
+  const articleType = loc.pathname.split("/")[2];
+  const ARTICLE = 1,
+    COMMENT = 2,
+    LIKED = 3;
   return (
     <>
       <MypageBlock>
         <main>
-          {isArticle ? (
+          {articleType ? (
             <MyArticleBoard
-              isComment={isArticle === "article" ? false : true}
+              articleType={
+                articleType === "article"
+                  ? ARTICLE
+                  : articleType === "comment"
+                  ? COMMENT
+                  : LIKED
+              }
             />
           ) : (
             <>
               <MyProfile />
               <div className="mypage-article">
-                <MyArticlePreview isComment={false} />
-                <MyArticlePreview isComment={true} />
+                <MyArticlePreview articleType={ARTICLE} />
+                <MyArticlePreview articleType={COMMENT} />
+                <MyArticlePreview articleType={LIKED} />
               </div>
             </>
           )}

--- a/src/components/pages/Mypage.jsx
+++ b/src/components/pages/Mypage.jsx
@@ -19,7 +19,7 @@ const Mypage = () => {
         <main>
           {isArticle ? (
             <MyArticleBoard
-              isComment={isArticle === "articles" ? false : true}
+              isComment={isArticle === "article" ? false : true}
             />
           ) : (
             <>

--- a/src/components/pages/Mypage.jsx
+++ b/src/components/pages/Mypage.jsx
@@ -12,8 +12,8 @@ const Mypage = () => {
         <main>
           <MyProfile />
           <div className="mypage-article">
-            <MyArticlePreview ifComment={false} />
-            <MyArticlePreview ifComment={true} />
+            <MyArticlePreview isComment={false} />
+            <MyArticlePreview isComment={true} />
           </div>
         </main>
         <aside>

--- a/src/components/pages/Mypage.jsx
+++ b/src/components/pages/Mypage.jsx
@@ -1,20 +1,35 @@
 import React from "react";
+import { useLocation } from "react-router-dom";
 import styled from "styled-components";
 
 import { Container } from "../atoms/global";
 import { QuickLink } from "../organisms/main";
-import { MyProfile, MyArticlePreview } from "../organisms/mypage";
+import {
+  MyProfile,
+  MyArticlePreview,
+  MyArticleBoard,
+} from "../organisms/mypage";
 
 const Mypage = () => {
+  const loc = useLocation();
+  const isArticle = loc.pathname.split("/")[2];
   return (
     <>
       <MypageBlock>
         <main>
-          <MyProfile />
-          <div className="mypage-article">
-            <MyArticlePreview isComment={false} />
-            <MyArticlePreview isComment={true} />
-          </div>
+          {isArticle ? (
+            <MyArticleBoard
+              isComment={isArticle === "articles" ? false : true}
+            />
+          ) : (
+            <>
+              <MyProfile />
+              <div className="mypage-article">
+                <MyArticlePreview isComment={false} />
+                <MyArticlePreview isComment={true} />
+              </div>
+            </>
+          )}
         </main>
         <aside>
           <QuickLink />

--- a/src/network/UserService.js
+++ b/src/network/UserService.js
@@ -198,13 +198,15 @@ const UserService = {
     }
     return response.data;
   },
-  getMyArticles: async () => {
+  getMyArticles: async (page) => {
     const method = "GET";
     const url = userUrl("/me/articles");
+    const params = { page };
 
     let response;
     try {
       response = await API.AXIOS({
+        params,
         method,
         url,
       });
@@ -213,13 +215,15 @@ const UserService = {
     }
     return response.data;
   },
-  getMyComments: async () => {
+  getMyComments: async (page) => {
     const method = "GET";
     const url = userUrl("/me/comments");
+    const params = { page };
 
     let response;
     try {
       response = await API.AXIOS({
+        params,
         method,
         url,
       });

--- a/src/network/UserService.js
+++ b/src/network/UserService.js
@@ -183,13 +183,15 @@ const UserService = {
     return response.data;
   },
   // 내 글, 내 댓글, 좋아요한 글 불러오기 추가
-  getLikeArticles: async () => {
+  getLikeArticles: async (page) => {
     const method = "GET";
     const url = userUrl("/me/like-articles");
+    const params = { page };
 
     let response;
     try {
       response = await API.AXIOS({
+        params,
         method,
         url,
       });


### PR DESCRIPTION
<img width="632" alt="image" src="https://user-images.githubusercontent.com/37893979/166149713-93f900df-b3d4-4ed7-b166-9d069871770f.png">

### 일반
- 마이페이지에서 더보기 버튼을 통해 바로 이동해도 어색함이 없도록 비슷하게 디자인했습니다
- 미리보기 게시물 개수를 5개로 제한했는데 유동적으로 바꿔도 상관없을거같아요
- 글, 댓글, 좋아요 컴포넌트를 같은 컴포넌트 내에서 articleType으로만 구분합니다

### 라우팅
- `/mypage/article` , `/mypage/comment` , `/mypage/liked` 라우팅 
- 동적라우팅을 사용하지 않은 이유는 `/mypage/aaa` 같이 존재하지 않는 (존재해서는 안될) 페이지까지 표시돼서 그냥 정적으로 박아넣었습니다
- 모달을 쓰지 않고 다른 페이지로 뺀 이유는 모달을 쓰면... 안이뻐서요...

### 좋아요
- 좋아요한 게시글의 존재를 잊어버리고 있었습니다...... 좋아요한 게시글 리스트도 띄워줍니다
- MyArticleBoard 하나의 컴포넌트에서 articleType props를 넘겨받아 글 / 댓글 / 좋아요 구분
- 좋아요한 게시글 프리뷰 컴포넌트는 너비를 길게 해주었습니다 (밸런스 문제)
- 게시글 5개 미리보기 컴포넌트는 확장성을 위해 높이를 따로 지정해주지 않았습니다 @PIut0 님 좋은의견 감사합니당~~

<img width="655" alt="image" src="https://user-images.githubusercontent.com/37893979/166149884-3890c058-5b56-41e1-b8c7-e68448c1d2ba.png">

### MyArticleBoard
- MyArticleBoard의 디자인과 페이지네이션 컴포넌트는 Board 컴포넌트를 매우많이 참고했습니다 
- (원래는 그대로 가져오려고 했으나 Board 컴포넌트 내에 게시글을 가져오는 API가 들어있어서 UserService API로 변경하기 위해 수정했습니다)
- 페이지네이션 컴포넌트도 그대로 가져오려 했으나 내 글, 내 댓글, 좋아요한 게시글은 게시글 가져오는 API에서 총 페이지 수를 meta로 보내주기 때문에 굳이 API를 한번 더 사용할 필요가 없어 제가 개조했습니다