### PR TITLE
Fix: preview article title

### DIFF
--- a/src/common/Preview/PreviewArticleItem.jsx
+++ b/src/common/Preview/PreviewArticleItem.jsx
@@ -38,6 +38,9 @@ const StyledPreviewItemContainer = styled.div`
 
 const StyledPreviewArticleTitle = styled.div`
   font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
 const StyledIcons = styled.div`

--- a/src/components/organisms/main/ArticlePreview.jsx
+++ b/src/components/organisms/main/ArticlePreview.jsx
@@ -51,6 +51,8 @@ const ArticlePreviewWrapper = styled.div`
 
 const ReactionWrapper = styled.div`
   display: flex;
+  width: max-content;
+  white-space: nowrap;
 
   & > span {
     display: flex;

--- a/src/components/pages/Mypage/styles/MyArticlePreview.styles.js
+++ b/src/components/pages/Mypage/styles/MyArticlePreview.styles.js
@@ -29,9 +29,11 @@ const StyledMyArticlePreview = styled.div`
     }
   }
   h3 {
-    height: 1.5rem;
-    display: flex;
+    margin: 0.4rem 0;
     align-items: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   .like,
   .comment {


### PR DESCRIPTION
## 변경 사항
게시글 미리보기에서 게시글 제목의 줄바꿈 방지 및 ... 추가

## 변경한 이유
게시글 미리보기에서 게시글 제목이 길어질 경우 줄바꿈이 되며 다른 디자인들이 깨지는 현상 수정
close: #76 

## 스크린샷 또는 관련 문서
### 변경전
#76 에서 확인

### 변경후
<img width="867" alt="image" src="https://user-images.githubusercontent.com/13381535/177809740-aaa1603c-352b-4dcc-b7dc-1c1fe5f19123.png">
