### PR TITLE
Fix: mypage comment link

### DIFF
--- a/src/components/pages/Mypage/components/MyArticleBoard.jsx
+++ b/src/components/pages/Mypage/components/MyArticleBoard.jsx
@@ -4,6 +4,7 @@ import PreviewArticle from '@components/organisms/category/PreviewArticle';
 import { useMyArticleBoard } from '@components/pages/Mypage/hooks';
 
 import { StyledMyArticleBoard, StyledMyArticlePageSelector } from '@components/pages/Mypage/styles';
+import constants from '../constants';
 
 const MyArticleBoard = ({ articleType }) => {
   const {
@@ -27,7 +28,8 @@ const MyArticleBoard = ({ articleType }) => {
       </div>
       <div className="article-list">
         {articles.map((article, id) => (
-          <Link to={`/article/${article.id}`} className="article-content" key={id}>
+          //TODO: article 이름 수정
+          <Link to={`/article/${articleType === constants.COMMENT ? article.article.id : article.id}`} className="article-content" key={id}>
             <PreviewArticle article={article} />
           </Link>
         ))}


### PR DESCRIPTION
Co-Authored-By: huni <46391729+Skyrich2000@users.noreply.github.com>

## 변경 사항
MyArticleBoard의 article-list의 Link to 수정

## 변경한 이유
Close #98 
mypage의 내 댓글 더보기에서 댓글 클릭시 commentId로 링크가 연결되고 있는 버그

## 스크린샷 또는 관련 문서
