### PR TITLE
Fix: css url로 포함된 이미지는 배포후에 안나오는 문제가 있어서 변경하였음

### DIFF
--- a/src/components/pages/Auth.jsx
+++ b/src/components/pages/Auth.jsx
@@ -13,7 +13,7 @@ const AuthBlock = styled.div`
   position: fixed;
   scrollbar-width: none;
 
-  background: url('assets/main_background.jpeg') no-repeat center center/cover;
+  background: url(${process.env.PUBLIC_URL} + '/assets/main_background.jpeg') no-repeat center center/cover;
 
   height: 100vh;
   width: 100%;

--- a/src/components/pages/login/Login.jsx
+++ b/src/components/pages/login/Login.jsx
@@ -47,7 +47,7 @@ const Container = styled.div`
   width: 100vw;
   height: 100vh;
 
-  background: url('assets/main_background.jpeg') no-repeat center center/cover;
+  background: url(${process.env.PUBLIC_URL} + '/assets/main_background.jpeg') no-repeat center center/cover;
 
   h1 {
     font-size: 1.2rem;


### PR DESCRIPTION
## 변경 사항
- css url로 포함된 이미지 url을 public_url과 합쳐서 사용하도록 수정
   - 문제는 이거를 배포하기 전에는 제대로 되는지 확인 할수가 없어서 배포를 해봐야함

## 변경한 이유
- css url로 포함된 이미지는 배포후에 안나오는 문제가 있어서 변경하였음

## 스크린샷 또는 관련 문서

<img width="730" alt="image" src="https://user-images.githubusercontent.com/8137615/179363378-0687ef1e-14f6-4182-8399-56e69017af8e.png">

https://create-react-app.dev/docs/using-the-public-folder/