### PR TITLE
Feat: open graph meta data

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,9 @@
 <html lang="ko">
   <head>
     <meta charset="utf-8" />
+    <meta property="og:title" content="42World" />
+    <meta property="og:description" content="42서울 재학생과 졸업생 모두를 아우르는 커뮤니티" />
+    <meta property="og:image" content="/assets/42worldCharacterLogo.jpg" />
     <link
       rel="icon"
       type="image/png"


### PR DESCRIPTION
## 변경 사항
미리보기에서 보이는 설명을 수정

## 변경한 이유
미리보기에서부터 매력적이어야 링크를 통한 유입을 늘릴 수 있음

## 스크린샷 또는 관련 문서
<img width="389" alt="image" src="https://user-images.githubusercontent.com/31057849/179791839-29fad44c-e1c6-44ec-ba8d-71cb05a7e2aa.png">
<img width="324" alt="image" src="https://user-images.githubusercontent.com/31057849/179796534-1693d5e2-fff9-4e77-801f-97c6227dbc7e.png">

추후에 각 uri별로 다른 미리보기를 띄우고 싶다면 (ex. 게시글에는 42world 게시판 같은 설명)
react-helmet을 이용하면 된다고 합니다