### PR TITLE
Fix: 게시글 리스트의 검색 창 placeholder 변경

### DIFF
--- a/src/components/pages/articles/ArticleListPage/components/ArticleListHeader.jsx
+++ b/src/components/pages/articles/ArticleListPage/components/ArticleListHeader.jsx
@@ -19,7 +19,7 @@ const ArticleListHeader = ({ hasQuery }) => {
               type="text"
               className="search"
               value={search}
-              placeholder="게시물 제목 검색"
+              placeholder="검색어를 입력해주세요"
             />
           </div>
         </form>


### PR DESCRIPTION
## 변경 사항
- 게시글 리스트의 검색 창 placeholder 변경

## 변경한 이유
- 게시물 제목 검색이라고 적혀있으나 실제로는 본문도 검색되기 때문에 수정

## 스크린샷 또는 관련 문서
<img width="674" alt="스크린샷 2022-08-15 오후 1 07 44" src="https://user-images.githubusercontent.com/8137615/184575502-11d5af04-8df5-488a-b907-5a6aa1a215c4.png">

