### PR TITLE
Fix: 게시글 상세 페이지, react query cache time

### DIFF
--- a/src/common/hooks/api/article.ts
+++ b/src/common/hooks/api/article.ts
@@ -38,7 +38,7 @@ export const useGetArticleById: GetArticle = (articleId, enable = true) => {
     {
       retry: false,
       enabled: enable,
-      cacheTime: 1000,
+      cacheTime: 0,
     },
   );
 

--- a/src/common/hooks/api/article.ts
+++ b/src/common/hooks/api/article.ts
@@ -38,7 +38,7 @@ export const useGetArticleById: GetArticle = (articleId, enable = true) => {
     {
       retry: false,
       enabled: enable,
-      cacheTime: 1,
+      cacheTime: 1000,
     },
   );
 

--- a/src/common/hooks/api/article.ts
+++ b/src/common/hooks/api/article.ts
@@ -16,7 +16,7 @@ export const useGetArticles: GetArticles = (categoryId, pageNumber = 1, enable =
   const { isError, data } = useQuery(
     [ARTICLES_URL, categoryId, pageNumber],
     () => ArticleService.getArticlesByCategoryId(categoryId, pageNumber, 10),
-    { enabled: enable, refetchOnMount: 'always' },
+    { enabled: enable, cacheTime: 1 },
   );
 
   return { isError, articles: data?.data ?? [], meta: data?.meta };
@@ -38,6 +38,7 @@ export const useGetArticleById: GetArticle = (articleId, enable = true) => {
     {
       retry: false,
       enabled: enable,
+      cacheTime: 1,
     },
   );
 

--- a/src/common/hooks/api/comment.ts
+++ b/src/common/hooks/api/comment.ts
@@ -6,7 +6,7 @@ export const useGetComments = (articleId: number, page: number, take?: 10) => {
     ['comments', articleId, page],
     () => CommentService2.getCommentsByArticleId(articleId, page, take),
     {
-      cacheTime: 1,
+      cacheTime: 1000,
     },
   );
 

--- a/src/common/hooks/api/comment.ts
+++ b/src/common/hooks/api/comment.ts
@@ -2,8 +2,12 @@ import { CommentService2 } from '@root/network';
 import { useQuery } from 'react-query';
 
 export const useGetComments = (articleId: number, page: number, take?: 10) => {
-  const { isError, data, refetch } = useQuery(['comments', articleId, page], () =>
-    CommentService2.getCommentsByArticleId(articleId, page, take),
+  const { isError, data, refetch } = useQuery(
+    ['comments', articleId, page],
+    () => CommentService2.getCommentsByArticleId(articleId, page, take),
+    {
+      cacheTime: 1,
+    },
   );
 
   return { isError, comments: data?.data, meta: data?.meta, refetch };

--- a/src/common/hooks/api/comment.ts
+++ b/src/common/hooks/api/comment.ts
@@ -6,7 +6,7 @@ export const useGetComments = (articleId: number, page: number, take?: 10) => {
     ['comments', articleId, page],
     () => CommentService2.getCommentsByArticleId(articleId, page, take),
     {
-      cacheTime: 1000,
+      cacheTime: 0,
     },
   );
 

--- a/src/common/hooks/api/search.ts
+++ b/src/common/hooks/api/search.ts
@@ -19,7 +19,7 @@ export const useGetSearchResults: UseGetSearchResults = (query, categoryId, page
     () => ArticleService2.getArticleSearch({ q: query, categoryId, page: pageNumber }),
     {
       enabled: enable,
-      cacheTime: 1000,
+      cacheTime: 0,
     },
   );
 

--- a/src/common/hooks/api/search.ts
+++ b/src/common/hooks/api/search.ts
@@ -19,7 +19,7 @@ export const useGetSearchResults: UseGetSearchResults = (query, categoryId, page
     () => ArticleService2.getArticleSearch({ q: query, categoryId, page: pageNumber }),
     {
       enabled: enable,
-      cacheTime: 1,
+      cacheTime: 1000,
     },
   );
 

--- a/src/common/hooks/api/search.ts
+++ b/src/common/hooks/api/search.ts
@@ -19,6 +19,7 @@ export const useGetSearchResults: UseGetSearchResults = (query, categoryId, page
     () => ArticleService2.getArticleSearch({ q: query, categoryId, page: pageNumber }),
     {
       enabled: enable,
+      cacheTime: 1,
     },
   );
 

--- a/src/common/hooks/api/user.js
+++ b/src/common/hooks/api/user.js
@@ -7,7 +7,7 @@ export const USERS_URL = '/users';
 export const USERS_ME_URL = '/users/me';
 
 export const useGetUser = () => {
-  const { isError, data } = useQuery([USERS_ME_URL], UserService.getUser);
+  const { isError, data } = useQuery([USERS_ME_URL], UserService.getUser, { cacheTime: 10 });
   return { isError, user: data?.data ?? {} };
 };
 

--- a/src/common/hooks/api/user.js
+++ b/src/common/hooks/api/user.js
@@ -7,7 +7,7 @@ export const USERS_URL = '/users';
 export const USERS_ME_URL = '/users/me';
 
 export const useGetUser = () => {
-  const { isError, data } = useQuery([USERS_ME_URL], UserService.getUser, { cacheTime: 10 });
+  const { isError, data } = useQuery([USERS_ME_URL], UserService.getUser, { cacheTime: 10 * 1000 });
   return { isError, user: data?.data ?? {} };
 };
 

--- a/src/components/pages/articles/ArticleDetailPage/components/comment/CommentsList.tsx
+++ b/src/components/pages/articles/ArticleDetailPage/components/comment/CommentsList.tsx
@@ -33,7 +33,7 @@ const CommentsList = ({ comments, meta, page, setPage, refetch }: CommentsListPr
     <div>
       {comments &&
         comments.map(comment => (
-          <CommentItem comment={comment} articleId={comment.articleId} handleDelete={handleDelete} />
+          <CommentItem key={comment.id} comment={comment} articleId={comment.articleId} handleDelete={handleDelete} />
         ))}
       {meta && <PageSelector currentPage={page} onChangePage={onChangePage} totalPageCount={meta.pageCount} />}
     </div>


### PR DESCRIPTION
## 변경 사항
- 게시글 상세 페이지에서 사용하는 react query cache time을 단축

## 변경한 이유
- 좋아요, 댓글 갯수, 댓글 목록이 최신화가 안되는 문제 수정

## 스크린샷 또는 관련 문서
