### PR TITLE
Fix: logo192 못찾는 에러 수정

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Web site created using create-react-app" />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/assets/42worldCharacterLogo.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "42World",
+  "name": "42World",
   "icons": [
     {
       "src": "favicon.ico",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -8,14 +8,9 @@
       "type": "image/x-icon"
     },
     {
-      "src": "logo192.png",
+      "src": "assets/42worldCharacterLogo.png",
       "type": "image/png",
-      "sizes": "192x192"
-    },
-    {
-      "src": "logo512.png",
-      "type": "image/png",
-      "sizes": "512x512"
+      "sizes": "1000x1000"
     }
   ],
   "start_url": ".",


### PR DESCRIPTION
## 변경 사항

index.html 에서 logo192.png 없는거 42월드 로고 파일로 수정

menifest 도 수정했는데, 이게 모바일에서 잘 되는지는 확인이 필요함
그리고 로고 사이즈가 기존에 192x192 인걸 1000x1000 으로 바꿨는데 이것도 괜찮은지 확인이 필요합니다.

## 변경한 이유

자꾸 콘솔 로그에 에러찍힘 ㅡ.ㅡ

## 스크린샷 또는 관련 문서
