### PR TITLE
chore: test ci nodejs version 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,17 +8,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [16.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 16.x
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 16.x
           cache: 'yarn'
       - run: yarn
       - run: yarn test


### PR DESCRIPTION
## 변경 사항
test ci nodejs verison 을 16으로 변경합니다.

## 변경한 이유
test ci nodejs version이 16 고정인데 matrix를 쓸 이유가없어서 수정합니다.

## 스크린샷 또는 관련 문서
