### PR TITLE
Feat: 댓글 정렬 순서 반대로 해달라는 피드백 반영

### DIFF
--- a/src/network/CommentService2.ts
+++ b/src/network/CommentService2.ts
@@ -11,7 +11,7 @@ type GetCommentsByArticleId = (
   order?: 'ASC' | 'DESC',
 ) => Promise<Pagination<Comment>>;
 
-const getCommentsByArticleId: GetCommentsByArticleId = async (articleId, page, take, order = 'DESC') => {
+const getCommentsByArticleId: GetCommentsByArticleId = async (articleId, page, take, order = 'ASC') => {
   const res = await apiClient.get(COMMENTS_URL(articleId), {
     params: {
       order,


### PR DESCRIPTION
## 변경 사항
- 댓글 정렬순서 반대로 변경

## 변경한 이유
- 현재는 최신 댓글이 가장 위에 올라오는데 사용자가 불편을 느껴서 반대로 변경하였음

## 스크린샷 또는 관련 문서
